### PR TITLE
Use the libcommunist subproject and ignore some directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+build/
+_build/
+builddir/
+subprojects/libcommunist
+.vscode
+.fenv
+.flatpak

--- a/meson.build
+++ b/meson.build
@@ -3,7 +3,7 @@ subdir ('src')
 src = ['main.cpp', srcfile]
 gtkmm = dependency ('gtkmm-4.0', method : 'pkg-config')
 icu = dependency ('icu-i18n', method : 'pkg-config')
-libcommunist = dependency ('libcommunist', method : 'pkg-config')
+libcommunist = dependency ('libcommunist', method : 'pkg-config', fallback : ['libcommunist','libcommunist_dep'])
 hunspell = dependency ('hunspell', method : 'pkg-config')
 thread_dep = dependency ('threads')
 subdir ('po')

--- a/subprojects/libcommunist.wrap
+++ b/subprojects/libcommunist.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/ProfessorNavigator/libcommunist
+revision = master
+depth = 1
+
+[provide]
+dependency_names = libcommunist

--- a/subprojects/libcommunist.wrap
+++ b/subprojects/libcommunist.wrap
@@ -4,4 +4,4 @@ revision = master
 depth = 1
 
 [provide]
-dependency_names = libcommunist
+libcommunist = libcommunist_dep


### PR DESCRIPTION
Allows to build the project if libcommunist isn't installed on the system side. Requires ProfessorNavigator/libcommunist#4.